### PR TITLE
첨부 파일 추가 기능 구현

### DIFF
--- a/src/app/assets/svg/Editor/FileSvg.tsx
+++ b/src/app/assets/svg/Editor/FileSvg.tsx
@@ -1,0 +1,20 @@
+export default function FileSvg({ className = '' }: { className?: string }) {
+  return (
+    <svg
+      xmlns='http://www.w3.org/2000/svg'
+      width='20'
+      height='20'
+      viewBox='0 0 24 24'
+      fill='none'
+      className={className}
+    >
+      <path
+        d='M20.3337 17.8333C20.3337 18.2754 20.1581 18.6993 19.8455 19.0118C19.5329 19.3244 19.109 19.5 18.667 19.5H5.33366C4.89163 19.5 4.46771 19.3244 4.15515 19.0118C3.84259 18.6993 3.66699 18.2754 3.66699 17.8333V6.16667C3.66699 5.72464 3.84259 5.30072 4.15515 4.98816C4.46771 4.67559 4.89163 4.5 5.33366 4.5H9.50033L11.167 7H18.667C19.109 7 19.5329 7.17559 19.8455 7.48816C20.1581 7.80072 20.3337 8.22464 20.3337 8.66667V17.8333Z'
+        stroke='currentColor'
+        strokeWidth='1.25'
+        strokeLinecap='round'
+        strokeLinejoin='round'
+      />
+    </svg>
+  );
+}

--- a/src/app/components/post/EditorMenu/EditorMenu.tsx
+++ b/src/app/components/post/EditorMenu/EditorMenu.tsx
@@ -2,6 +2,7 @@
 
 import { EditorMenuButton } from '../EditorMenuButton/EditorMenuButton';
 import EditorImageButton from '../EditorMenuButton/EditorImageButton';
+import EditorFileButton from '../EditorMenuButton/EditorFileButton';
 import Select from '../../apply/Select/Select';
 import {
   basicButtons,
@@ -38,6 +39,8 @@ const EditorMenu = ({
   return (
     <div className={styles.editorMenu}>
       <EditorImageButton editor={editor} />
+      <EditorFileButton editor={editor} />
+
       <div className={styles.editorMenuDivider} />
       {buttonGroups.map((group) => (
         <>

--- a/src/app/components/post/EditorMenuButton/EditorFileButton.tsx
+++ b/src/app/components/post/EditorMenuButton/EditorFileButton.tsx
@@ -1,0 +1,44 @@
+import FileSvg from '@/app/assets/svg/Editor/FileSvg';
+import type { Editor } from '@tiptap/react';
+import type { FileInfo } from '../FileNode/FileComponent';
+import styles from './EditorMenuButton.module.scss';
+
+interface EditorFileButtonProps {
+  editor: Editor;
+}
+
+const EditorFileButton = ({ editor }: EditorFileButtonProps) => {
+  const getFileInfo = (file: File): FileInfo => {
+    const fileUrl = URL.createObjectURL(file);
+    const fileSize = (file.size / (1024 * 1024)).toFixed(2) + 'MB';
+
+    let fileName = file.name;
+    let fileType = '';
+
+    const lastDotIndex = file.name.lastIndexOf('.');
+
+    if (lastDotIndex !== -1) {
+      fileName = file.name.slice(0, lastDotIndex);
+      fileType = file.name.slice(lastDotIndex + 1);
+    }
+
+    return { fileUrl, fileSize, fileName, fileType };
+  };
+
+  const handleEditorFile = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+
+    if (!file) return;
+
+    const fileInfo = getFileInfo(file);
+  };
+
+  return (
+    <label className={styles.editorMenuButton}>
+      <input type='file' hidden onChange={handleEditorFile} />
+      <FileSvg />
+    </label>
+  );
+};
+
+export default EditorFileButton;

--- a/src/app/components/post/EditorMenuButton/EditorFileButton.tsx
+++ b/src/app/components/post/EditorMenuButton/EditorFileButton.tsx
@@ -11,7 +11,6 @@ const EditorFileButton = ({ editor }: EditorFileButtonProps) => {
   const getFileInfo = (file: File): FileInfo => {
     const fileUrl = URL.createObjectURL(file);
     const fileSize = (file.size / (1024 * 1024)).toFixed(2) + 'MB';
-
     let fileName = file.name;
     let fileType = '';
 
@@ -25,12 +24,23 @@ const EditorFileButton = ({ editor }: EditorFileButtonProps) => {
     return { fileUrl, fileSize, fileName, fileType };
   };
 
+  const insertFilePreview = (fileInfo: FileInfo) => {
+    const content = {
+      type: 'fileNode',
+      attrs: fileInfo,
+    };
+
+    editor?.commands.insertContent(content);
+  };
+
   const handleEditorFile = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
 
     if (!file) return;
 
     const fileInfo = getFileInfo(file);
+
+    insertFilePreview(fileInfo);
   };
 
   return (

--- a/src/app/components/post/FileNode/FileComponent.module.scss
+++ b/src/app/components/post/FileNode/FileComponent.module.scss
@@ -1,0 +1,75 @@
+@import 'mixin';
+
+.fileContainer {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 0.5rem;
+
+  .fileContent {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.8rem 1rem;
+    box-shadow: 0 1px 4px 0 rgba(0, 0, 0, 0.07);
+    border: 1px solid var(--color-gray-500);
+
+    .icon {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+
+      svg {
+        width: 2rem;
+        height: 2rem;
+        fill: var(--color-black-100);
+        color: transparent;
+      }
+    }
+
+    .desc {
+      display: flex;
+      flex-direction: column;
+      justify-content: space-evenly;
+      width: 28rem;
+      height: 3.5rem;
+
+      .fileName {
+        @include title2(black-85);
+
+        display: flex;
+        align-items: center;
+        max-width: 100%;
+        overflow: hidden;
+
+        .name {
+          min-width: 0;
+          max-width: 70%;
+          overflow: hidden;
+          white-space: nowrap;
+          text-overflow: ellipsis;
+        }
+
+        .type {
+          flex-shrink: 0;
+        }
+      }
+
+      .fileSize {
+        @include title3(secondary);
+      }
+    }
+
+    &:hover {
+      cursor: pointer;
+    }
+
+    &:active {
+      cursor: pointer;
+      border: 2px solid var(--color-gray-900);
+    }
+
+    &.selected {
+      border: 2px solid black;
+    }
+  }
+}

--- a/src/app/components/post/FileNode/FileComponent.tsx
+++ b/src/app/components/post/FileNode/FileComponent.tsx
@@ -18,9 +18,8 @@ const FileComponent = ({ node, selected }: NodeViewProps) => {
     <NodeViewWrapper>
       <figure
         className={styles.fileContainer}
-        draggable={true}
+        draggable
         data-drag-handle
-        contentEditable='false'
       >
         <div
           className={clsx(styles.fileContent, {

--- a/src/app/components/post/FileNode/FileComponent.tsx
+++ b/src/app/components/post/FileNode/FileComponent.tsx
@@ -1,0 +1,46 @@
+import { NodeViewWrapper } from '@tiptap/react';
+import clsx from 'clsx';
+import FileSvg from '@/app/assets/svg/Editor/FileSvg';
+import type { NodeViewProps } from '@tiptap/react';
+import styles from './FileComponent.module.scss';
+
+export interface FileInfo {
+  fileName: string;
+  fileType: string;
+  fileSize: string;
+  fileUrl: string;
+}
+
+const FileComponent = ({ node, selected }: NodeViewProps) => {
+  const { fileName, fileType, fileSize } = node.attrs as FileInfo;
+
+  return (
+    <NodeViewWrapper>
+      <figure
+        className={styles.fileContainer}
+        draggable={true}
+        data-drag-handle
+        contentEditable='false'
+      >
+        <div
+          className={clsx(styles.fileContent, {
+            [styles.selected]: selected,
+          })}
+        >
+          <div className={styles.icon}>
+            <FileSvg />
+          </div>
+          <div className={styles.desc}>
+            <div className={styles.fileName}>
+              <span className={styles.name}>{fileName}</span>
+              <span className={styles.type}>.{fileType}</span>
+            </div>
+            <span className={styles.fileSize}>{fileSize}</span>
+          </div>
+        </div>
+      </figure>
+    </NodeViewWrapper>
+  );
+};
+
+export default FileComponent;

--- a/src/app/components/post/FileNode/FileNode.ts
+++ b/src/app/components/post/FileNode/FileNode.ts
@@ -1,0 +1,25 @@
+import { Node } from '@tiptap/core';
+import { ReactNodeViewRenderer } from '@tiptap/react';
+import FileComponent from './FileComponent';
+
+const FileNode = Node.create({
+  name: 'fileNode',
+  group: 'block',
+  atom: true,
+  draggable: true,
+
+  addAttributes() {
+    return {
+      fileName: { default: null },
+      fileType: { default: null },
+      fileSize: { default: null },
+      fileUrl: { default: null },
+    };
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(FileComponent);
+  },
+});
+
+export default FileNode;

--- a/src/app/components/post/FileNode/FileNode.ts
+++ b/src/app/components/post/FileNode/FileNode.ts
@@ -17,6 +17,55 @@ const FileNode = Node.create({
     };
   },
 
+  renderHTML({ node }) {
+    const { fileName, fileType, fileSize, fileUrl } = node.attrs;
+
+    return [
+      'figure',
+      { class: 'editorFileContainer' },
+      [
+        'a',
+        { class: 'editorFileContent', href: fileUrl, download: fileName },
+        [
+          'div',
+          { class: 'editorFileIcon' },
+          [
+            'svg',
+            {
+              xmlns: 'http://www.w3.org/2000/svg',
+              width: '20',
+              height: '20',
+              viewBox: '0 0 24 24',
+              fill: 'none',
+              class: 'editorFileIconSvg',
+            },
+            [
+              'path',
+              {
+                d: 'M20.3337 17.8333C20.3337 18.2754 20.1581 18.6993 19.8455 19.0118C19.5329 19.3244 19.109 19.5 18.667 19.5H5.33366C4.89163 19.5 4.46771 19.3244 4.15515 19.0118C3.84259 18.6993 3.66699 18.2754 3.66699 17.8333V6.16667C3.66699 5.72464 3.84259 5.30072 4.15515 4.98816C4.46771 4.67559 4.89163 4.5 5.33366 4.5H9.50033L11.167 7H18.667C19.109 7 19.5329 7.17559 19.8455 7.48816C20.1581 7.80072 20.3337 8.22464 20.3337 8.66667V17.8333Z',
+                stroke: 'currentColor',
+                strokeWidth: '1.25',
+                strokeLinecap: 'round',
+                strokeLinejoin: 'round',
+              },
+            ],
+          ],
+        ],
+        [
+          'div',
+          { class: 'editorFileDescription' },
+          [
+            'div',
+            { class: 'editorFileNameWrapper' },
+            ['span', { class: 'editorFileName' }, fileName],
+            ['span', { class: 'editorFileType' }, `.${fileType}`],
+          ],
+          ['span', { class: 'editorFileSize' }, fileSize],
+        ],
+      ],
+    ];
+  },
+
   addNodeView() {
     return ReactNodeViewRenderer(FileComponent);
   },

--- a/src/app/post/page.tsx
+++ b/src/app/post/page.tsx
@@ -6,6 +6,7 @@ import StarterKit from '@tiptap/starter-kit';
 import Underline from '@tiptap/extension-underline';
 import TextAlign from '@tiptap/extension-text-align';
 import CustomImage from '../components/post/ImageNode/ImageNode';
+import FileNode from '../components/post/FileNode/FileNode';
 import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight';
 import { all, createLowlight } from 'lowlight';
 import Header from '../components/post/Header/Header';
@@ -29,6 +30,7 @@ export default function Post() {
         CodeBlockLowlight.configure({
           lowlight,
         }),
+        FileNode,
       ],
       enablePasteRules: isMarkdwonMode,
       enableInputRules: isMarkdwonMode,


### PR DESCRIPTION
## 📌 관련 이슈

- https://github.com/Kumoh-talk/kumoh-talk-Frontend/issues/50

## ✨ PR 세부 내용

- 첨부 파일 추가 기능 구현
  - 첨부파일 요구사항에 따른 커스텀 컴포넌트 및 기능을 구현
  - 첨부 파일 조회 시 사용될 serialized HTML 구조 추가

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/0c1c1f93-ca05-4ba9-86f2-4b78dcf9dc81)


## ✅ 리뷰 요구사항
- 파일 클릭 시 다운로드는 게시물 작성 중에는 되지 않고, 조회 시에만 가능하도록 구현했습니다.
- 첨부파일은 한 게시물 당 하나만 저장되기에 첨부 파일 수정 UX에 대한 논의가 필요할 것 같습니다.