### PR TITLE
링크 미리보기 추가 기능 구현

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -10,6 +10,12 @@ const nextConfig = {
   },
   images: {
     domains: ['kumoh-talk-bucket.s3.ap-northeast-2.amazonaws.com'],
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: '**',
+      },
+    ],
   },
 };
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "jsonwebtoken": "^9.0.2",
     "lucide-react": "^0.469.0",
     "next": "14.2.5",
+    "open-graph-scraper": "^6.9.0",
     "react": "^18",
     "react-dom": "^18",
     "react-hook-form": "^7.54.0",

--- a/src/app/api/metadata/route.ts
+++ b/src/app/api/metadata/route.ts
@@ -1,0 +1,36 @@
+import ogs from 'open-graph-scraper';
+import { NextResponse } from 'next/server';
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const url = searchParams.get('url');
+
+  if (!url) {
+    return NextResponse.json(
+      { error: '유효한 URL을 제공해주세요.' },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const options = {
+      url,
+      onlyGetOpenGraphInfo: true,
+      headers: {
+        'user-agent': 'Googlebot/2.1 (+http://www.google.com/bot.html)',
+      },
+    };
+
+    const data = await ogs(options);
+
+    return NextResponse.json(data, { status: 200 });
+  } catch (error: any) {
+    return NextResponse.json(
+      {
+        error: '메타 데이터 추출 중 오류가 발생했습니다.',
+        result: error.message,
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/components/post/LinkPreview/LinkPreviewComponent.module.scss
+++ b/src/app/components/post/LinkPreview/LinkPreviewComponent.module.scss
@@ -1,0 +1,72 @@
+@import 'mixin';
+
+.linkPreviewContainer {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  margin-bottom: 0.5rem;
+
+  .linkPreviewContent {
+    display: flex;
+    align-items: center;
+    min-width: 100%;
+    box-shadow: 0 1px 4px 0 rgba(0, 0, 0, 0.17);
+    border: 1px solid var(--color-gray-500);
+
+    .ogImage {
+      position: relative;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      width: 20%;
+      aspect-ratio: 1/1;
+      flex-shrink: 0;
+
+      img {
+        border: none;
+      }
+    }
+
+    .ogInfo {
+      display: flex;
+      flex-direction: column;
+      justify-content: space-evenly;
+      flex: 1;
+      height: 100%;
+      padding: 0.8rem 1.6rem;
+      max-width: 80%;
+
+      span {
+        max-width: 100%;
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+      }
+
+      .ogTitle {
+        @include title1(black-85);
+      }
+
+      .ogDescription {
+        @include title3(secondary);
+      }
+
+      .ogUrl {
+        @include callout(secondary);
+      }
+    }
+
+    &:hover {
+      cursor: pointer;
+    }
+
+    &:active {
+      cursor: pointer;
+      border: 2px solid var(--color-gray-900);
+    }
+  }
+
+  &.selected {
+    border: 2px solid black;
+  }
+}

--- a/src/app/components/post/LinkPreview/LinkPreviewComponent.module.scss
+++ b/src/app/components/post/LinkPreview/LinkPreviewComponent.module.scss
@@ -70,3 +70,45 @@
     border: 2px solid black;
   }
 }
+
+@keyframes shimmer {
+  0% {
+    background-position: -200% 0;
+  }
+  100% {
+    background-position: 200% 0;
+  }
+}
+
+.skeleton {
+  display: flex;
+  width: 100%;
+  height: fit-content;
+  box-shadow: 0 1px 4px 0 rgba(0, 0, 0, 0.17);
+  border: 1px solid var(--color-gray-800);
+
+  .skeletonImage {
+    width: 20%;
+    aspect-ratio: 1 / 1;
+    background: linear-gradient(90deg, #ddd 25%, #eee 50%, #ddd 75%);
+    background-size: 200% 100%;
+    animation: shimmer 3.5s infinite linear;
+  }
+
+  .skeletonInfo {
+    width: 80%;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-evenly;
+    align-items: center;
+  }
+
+  .skeletonText {
+    width: 90%;
+    height: 1rem;
+    border-radius: 0.5rem;
+    background: linear-gradient(90deg, #ddd 25%, #eee 50%, #ddd 75%);
+    background-size: 200% 100%;
+    animation: shimmer 3.5s infinite linear;
+  }
+}

--- a/src/app/components/post/LinkPreview/LinkPreviewComponent.tsx
+++ b/src/app/components/post/LinkPreview/LinkPreviewComponent.tsx
@@ -1,0 +1,48 @@
+import { NodeViewWrapper } from '@tiptap/react';
+import Image from 'next/image';
+import clsx from 'clsx';
+import type { NodeViewProps } from '@tiptap/react';
+import styles from './LinkPreviewComponent.module.scss';
+
+export interface LinkPreviewInfo {
+  ogImage: string;
+  ogTitle: string;
+  ogDescription: string;
+  ogUrl: string;
+  requestedUrl: string;
+}
+
+const LinkPreviewComponent = ({ node, selected }: NodeViewProps) => {
+  const { ogImage, ogTitle, ogDescription, ogUrl } =
+    (node.attrs as LinkPreviewInfo) || {};
+
+  return (
+    <NodeViewWrapper>
+      <figure
+        className={clsx(styles.linkPreviewContainer, {
+          [styles.selected]: selected,
+        })}
+        draggable={true}
+        data-drag-handle
+      >
+        <div className={styles.linkPreviewContent}>
+          <div className={styles.ogImage}>
+            <Image
+              src={ogImage}
+              alt={`${ogTitle}-image`}
+              fill
+              objectFit='cover'
+            />
+          </div>
+          <div className={styles.ogInfo}>
+            <span className={styles.ogTitle}>{ogTitle}</span>
+            <span className={styles.ogDescription}>{ogDescription}</span>
+            <span className={styles.ogUrl}>{ogUrl}</span>
+          </div>
+        </div>
+      </figure>
+    </NodeViewWrapper>
+  );
+};
+
+export default LinkPreviewComponent;

--- a/src/app/components/post/LinkPreview/LinkPreviewComponent.tsx
+++ b/src/app/components/post/LinkPreview/LinkPreviewComponent.tsx
@@ -10,37 +10,49 @@ export interface LinkPreviewInfo {
   ogDescription: string;
   ogUrl: string;
   requestedUrl: string;
+  isLoading: boolean;
 }
 
 const LinkPreviewComponent = ({ node, selected }: NodeViewProps) => {
-  const { ogImage, ogTitle, ogDescription, ogUrl } =
+  const { ogImage, ogTitle, ogDescription, ogUrl, isLoading } =
     (node.attrs as LinkPreviewInfo) || {};
 
   return (
     <NodeViewWrapper>
-      <figure
-        className={clsx(styles.linkPreviewContainer, {
-          [styles.selected]: selected,
-        })}
-        draggable={true}
-        data-drag-handle
-      >
-        <div className={styles.linkPreviewContent}>
-          <div className={styles.ogImage}>
-            <Image
-              src={ogImage}
-              alt={`${ogTitle}-image`}
-              fill
-              objectFit='cover'
-            />
-          </div>
-          <div className={styles.ogInfo}>
-            <span className={styles.ogTitle}>{ogTitle}</span>
-            <span className={styles.ogDescription}>{ogDescription}</span>
-            <span className={styles.ogUrl}>{ogUrl}</span>
+      {isLoading ? (
+        <div className={styles.skeleton}>
+          <div className={styles.skeletonImage} />
+          <div className={styles.skeletonInfo}>
+            <span className={styles.skeletonText} />
+            <span className={styles.skeletonText} />
+            <span className={styles.skeletonText} />
           </div>
         </div>
-      </figure>
+      ) : (
+        <figure
+          className={clsx(styles.linkPreviewContainer, {
+            [styles.selected]: selected,
+          })}
+          draggable={true}
+          data-drag-handle
+        >
+          <div className={styles.linkPreviewContent}>
+            <div className={styles.ogImage}>
+              <Image
+                src={ogImage}
+                alt={`${ogTitle}-image`}
+                fill
+                objectFit='cover'
+              />
+            </div>
+            <div className={styles.ogInfo}>
+              <span className={styles.ogTitle}>{ogTitle}</span>
+              <span className={styles.ogDescription}>{ogDescription}</span>
+              <span className={styles.ogUrl}>{ogUrl}</span>
+            </div>
+          </div>
+        </figure>
+      )}
     </NodeViewWrapper>
   );
 };

--- a/src/app/components/post/LinkPreview/LinkPreviewNode.ts
+++ b/src/app/components/post/LinkPreview/LinkPreviewNode.ts
@@ -18,6 +18,38 @@ const LinkPreviewNode = Node.create({
     };
   },
 
+  renderHTML({ node }) {
+    const { ogImage, ogTitle, ogDescription, ogUrl, requestedUrl } = node.attrs;
+
+    return [
+      'figure',
+      {
+        class: 'editorLinkPreviewContainer',
+      },
+      [
+        'a',
+        {
+          class: 'editorLinkPreviewContent',
+          href: requestedUrl,
+          target: '_blank',
+          'source-url': requestedUrl,
+        },
+        [
+          'div',
+          { class: 'editorLinkPreviewImage' },
+          ['img', { src: ogImage, alt: `${ogTitle}-image` }],
+        ],
+        [
+          'div',
+          { class: 'editorLinkPreviewInfo' },
+          ['span', { class: 'editorLinkPreviewTitle' }, ogTitle],
+          ['span', { class: 'editorLinkPreviewDescription' }, ogDescription],
+          ['span', { class: 'editorLinkPreviewUrl' }, ogUrl],
+        ],
+      ],
+    ];
+  },
+
   addNodeView() {
     return ReactNodeViewRenderer(LinkPreviewComponent, { as: 'figure' });
   },

--- a/src/app/components/post/LinkPreview/LinkPreviewNode.ts
+++ b/src/app/components/post/LinkPreview/LinkPreviewNode.ts
@@ -1,0 +1,26 @@
+import { Node } from '@tiptap/core';
+import { ReactNodeViewRenderer } from '@tiptap/react';
+import LinkPreviewComponent from './LinkPreviewComponent';
+
+const LinkPreviewNode = Node.create({
+  name: 'linkPreviewNode',
+  group: 'block',
+  atom: true,
+  draggable: true,
+
+  addAttributes() {
+    return {
+      ogImage: { default: '' },
+      ogTitle: { default: '' },
+      ogDescription: { default: '' },
+      ogUrl: { default: '' },
+      requestedUrl: { default: '' },
+    };
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(LinkPreviewComponent, { as: 'figure' });
+  },
+});
+
+export default LinkPreviewNode;

--- a/src/app/components/post/LinkPreview/LinkPreviewNode.ts
+++ b/src/app/components/post/LinkPreview/LinkPreviewNode.ts
@@ -15,6 +15,7 @@ const LinkPreviewNode = Node.create({
       ogDescription: { default: '' },
       ogUrl: { default: '' },
       requestedUrl: { default: '' },
+      isLoading: { default: true },
     };
   },
 

--- a/src/app/lib/apis/post/getMetadata.ts
+++ b/src/app/lib/apis/post/getMetadata.ts
@@ -1,0 +1,32 @@
+'use server';
+
+const getMetadataFromUrl = async (url: string) => {
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+  const response = await fetch(
+    `${baseUrl}/api/metadata?url=${encodeURIComponent(url)}`
+  );
+
+  if (!response.ok) {
+    throw new Error(`메타 데이터 호출에 실패했습니다. URL: ${url}`);
+  }
+
+  const data = await response.json();
+
+  return data?.result;
+};
+
+export async function getMetadata(url: string) {
+  const result = await getMetadataFromUrl(url);
+
+  if (!result) return null;
+
+  const { ogImage = [], ogTitle = '', ogDescription = '', ogUrl = '' } = result;
+
+  return {
+    ogImage: ogImage[0]?.url || '/images/logo.png',
+    ogTitle,
+    ogDescription,
+    ogUrl,
+    requestedUrl: url,
+  };
+}

--- a/src/app/lib/apis/post/getMetadata.ts
+++ b/src/app/lib/apis/post/getMetadata.ts
@@ -15,8 +15,19 @@ const getMetadataFromUrl = async (url: string) => {
   return data?.result;
 };
 
+const getMetadataFromHostUrl = async (url: string) => {
+  const hostUrl = new URL(url).origin;
+  const result = await getMetadataFromUrl(hostUrl);
+
+  return result;
+};
+
 export async function getMetadata(url: string) {
-  const result = await getMetadataFromUrl(url);
+  let result = await getMetadataFromUrl(url);
+
+  if (!result || (!result.ogTitle && !result.ogDescription)) {
+    result = await getMetadataFromHostUrl(url);
+  }
 
   if (!result) return null;
 

--- a/src/app/lib/hooks/post/useEditorLink.ts
+++ b/src/app/lib/hooks/post/useEditorLink.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, MouseEvent } from 'react';
+import { getMetadata } from '../../apis/post/getMetadata';
 import type { Editor } from '@tiptap/react';
 
 const useEditorLinkState = (editor: Editor) => {
@@ -53,6 +54,22 @@ const useEditorLinkActions = (
     editor.chain().focus().insertContent(content).run();
   };
 
+  const insertLinkPreview = async () => {
+    try {
+      const ogData = await getMetadata(linkUrl);
+      if (!ogData) return;
+
+      const linkPreview = {
+        type: 'linkPreviewNode',
+        attrs: ogData,
+      };
+
+      editor?.commands.insertContent(linkPreview);
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
   const setLink = (e: MouseEvent, callback?: () => void) => {
     e.preventDefault();
 
@@ -63,6 +80,8 @@ const useEditorLinkActions = (
     } else {
       setLinkAtText();
     }
+
+    insertLinkPreview();
 
     if (callback) {
       callback();

--- a/src/app/lib/hooks/post/useEditorLink.ts
+++ b/src/app/lib/hooks/post/useEditorLink.ts
@@ -54,6 +54,26 @@ const useEditorLinkActions = (
     editor.chain().focus().insertContent(content).run();
   };
 
+  const deleteLinkPreviewNodes = (targetUrl: string) => {
+    editor.commands.command(({ tr, state, dispatch }) => {
+      let deleted = false;
+
+      state.doc.descendants((node, pos) => {
+        if (
+          node.type.name === 'linkPreviewNode' &&
+          node.attrs.requestedUrl === targetUrl
+        ) {
+          if (dispatch) {
+            tr.delete(pos, pos + node.nodeSize);
+          }
+          deleted = true;
+        }
+      });
+
+      return deleted;
+    });
+  };
+
   const insertLinkPreview = async () => {
     try {
       const linkPreview = {
@@ -75,6 +95,7 @@ const useEditorLinkActions = (
       });
     } catch (error) {
       console.error(error);
+      deleteLinkPreviewNodes(linkUrl);
     }
   };
 

--- a/src/app/lib/hooks/post/useEditorLink.ts
+++ b/src/app/lib/hooks/post/useEditorLink.ts
@@ -56,17 +56,25 @@ const useEditorLinkActions = (
 
   const insertLinkPreview = async () => {
     try {
+      const linkPreview = {
+        type: 'linkPreviewNode',
+        attrs: {
+          isLoading: true,
+          requestedUrl: linkUrl,
+        },
+      };
+
+      editor.commands.insertContent(linkPreview);
+
       const ogData = await getMetadata(linkUrl);
       if (!ogData) return;
 
-      const linkPreview = {
-        type: 'linkPreviewNode',
-        attrs: ogData,
-      };
-
-      editor?.commands.insertContent(linkPreview);
+      editor.commands.updateAttributes('linkPreviewNode', {
+        ...ogData,
+        isLoading: false,
+      });
     } catch (error) {
-      console.log(error);
+      console.error(error);
     }
   };
 

--- a/src/app/post/page.tsx
+++ b/src/app/post/page.tsx
@@ -8,6 +8,7 @@ import TextAlign from '@tiptap/extension-text-align';
 import CustomImage from '../components/post/ImageNode/ImageNode';
 import FileNode from '../components/post/FileNode/FileNode';
 import Link from '@tiptap/extension-link';
+import LinkPreviewNode from '../components/post/LinkPreview/LinkPreviewNode';
 import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight';
 import { all, createLowlight } from 'lowlight';
 import Header from '../components/post/Header/Header';
@@ -35,6 +36,7 @@ export default function Post() {
           autolink: true,
           defaultProtocol: 'https',
         }),
+        LinkPreviewNode,
         FileNode,
       ],
       enablePasteRules: isMarkdwonMode,

--- a/yarn.lock
+++ b/yarn.lock
@@ -867,6 +867,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+boolbase@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
+  integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -945,6 +950,40 @@ chalk@^4.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chardet@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/chardet/-/chardet-2.1.0.tgz#1007f441a1ae9f9199a4a67f6e978fb0aa9aa3fe"
+  integrity sha512-bNFETTG/pM5ryzQ9Ad0lJOTa6HWD/YsScAR3EnCPZRPlQh77JocYktSHOUHelyhm8IARL+o4c4F1bP5KVOjiRA==
+
+cheerio-select@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/cheerio-select/-/cheerio-select-2.1.0.tgz#4d8673286b8126ca2a8e42740d5e3c4884ae21b4"
+  integrity sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==
+  dependencies:
+    boolbase "^1.0.0"
+    css-select "^5.1.0"
+    css-what "^6.1.0"
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
+    domutils "^3.0.1"
+
+cheerio@^1.0.0-rc.12:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0.tgz#1ede4895a82f26e8af71009f961a9b8cb60d6a81"
+  integrity sha512-quS9HgjQpdaXOvsZz82Oz7uxtXiy6UIsIQcpBj7HRw2M63Skasm9qlDocAM7jNuaxdhpPU7c4kJN+gA5MCu4ww==
+  dependencies:
+    cheerio-select "^2.1.0"
+    dom-serializer "^2.0.0"
+    domhandler "^5.0.3"
+    domutils "^3.1.0"
+    encoding-sniffer "^0.2.0"
+    htmlparser2 "^9.1.0"
+    parse5 "^7.1.2"
+    parse5-htmlparser2-tree-adapter "^7.0.0"
+    parse5-parser-stream "^7.1.2"
+    undici "^6.19.5"
+    whatwg-mimetype "^4.0.0"
+
 chokidar@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-4.0.3.tgz#7be37a4c03c9aee1ecfe862a4a23b2c70c205d30"
@@ -992,6 +1031,22 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.2:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
+
+css-select@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-5.1.0.tgz#b8ebd6554c3637ccc76688804ad3f6a6fdaea8a6"
+  integrity sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==
+  dependencies:
+    boolbase "^1.0.0"
+    css-what "^6.1.0"
+    domhandler "^5.0.2"
+    domutils "^3.0.1"
+    nth-check "^2.0.1"
+
+css-what@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-6.1.0.tgz#fb5effcf76f1ddea2c81bdfaa4de44e79bac70f4"
+  integrity sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==
 
 csstype@^3.0.2:
   version "3.1.3"
@@ -1110,6 +1165,36 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
+dom-serializer@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-2.0.0.tgz#e41b802e1eedf9f6cae183ce5e622d789d7d8e53"
+  integrity sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==
+  dependencies:
+    domelementtype "^2.3.0"
+    domhandler "^5.0.2"
+    entities "^4.2.0"
+
+domelementtype@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.3.0.tgz#5c45e8e869952626331d7aab326d01daf65d589d"
+  integrity sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==
+
+domhandler@^5.0.2, domhandler@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-5.0.3.tgz#cc385f7f751f1d1fc650c21374804254538c7d31"
+  integrity sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==
+  dependencies:
+    domelementtype "^2.3.0"
+
+domutils@^3.0.1, domutils@^3.1.0:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-3.2.2.tgz#edbfe2b668b0c1d97c24baf0f1062b132221bc78"
+  integrity sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==
+  dependencies:
+    dom-serializer "^2.0.0"
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
+
 dunder-proto@^1.0.0, dunder-proto@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/dunder-proto/-/dunder-proto-1.0.1.tgz#d7ae667e1dc83482f8b70fd0f6eefc50da30f58a"
@@ -1141,6 +1226,14 @@ emoji-regex@^9.2.2:
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72"
   integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
 
+encoding-sniffer@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/encoding-sniffer/-/encoding-sniffer-0.2.0.tgz#799569d66d443babe82af18c9f403498365ef1d5"
+  integrity sha512-ju7Wq1kg04I3HtiYIOrUrdfdDvkyO9s5XM8QAj/bN61Yo/Vb4vgJxy5vi4Yxk01gWHbrofpPtpxM8bKger9jhg==
+  dependencies:
+    iconv-lite "^0.6.3"
+    whatwg-encoding "^3.1.1"
+
 enhanced-resolve@^5.15.0:
   version "5.18.0"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.18.0.tgz#91eb1db193896b9801251eeff1c6980278b1e404"
@@ -1149,7 +1242,7 @@ enhanced-resolve@^5.15.0:
     graceful-fs "^4.2.4"
     tapable "^2.2.0"
 
-entities@^4.4.0:
+entities@^4.2.0, entities@^4.4.0, entities@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
   integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
@@ -1758,6 +1851,23 @@ highlight.js@~11.11.0:
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-11.11.1.tgz#fca06fa0e5aeecf6c4d437239135fabc15213585"
   integrity sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==
 
+htmlparser2@^9.1.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-9.1.0.tgz#cdb498d8a75a51f739b61d3f718136c369bc8c23"
+  integrity sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==
+  dependencies:
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
+    domutils "^3.1.0"
+    entities "^4.5.0"
+
+iconv-lite@0.6.3, iconv-lite@^0.6.3:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
+  integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
+
 ignore@^5.2.0:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.2.tgz#3cd40e729f3643fd87cb04e50bf0eb722bc596f5"
@@ -2319,6 +2429,13 @@ node-addon-api@^7.0.0:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-7.1.1.tgz#1aba6693b0f255258a049d621329329322aad558"
   integrity sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==
 
+nth-check@^2.0.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-2.1.1.tgz#c9eab428effce36cd6b92c924bdb000ef1f1ed1d"
+  integrity sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==
+  dependencies:
+    boolbase "^1.0.0"
+
 object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
@@ -2391,6 +2508,16 @@ once@^1.3.0:
   dependencies:
     wrappy "1"
 
+open-graph-scraper@^6.9.0:
+  version "6.9.0"
+  resolved "https://registry.yarnpkg.com/open-graph-scraper/-/open-graph-scraper-6.9.0.tgz#e3121144b99fbef1f05b944aacabe6f149e16be4"
+  integrity sha512-1KoV5v6GT0/MqlryrVGQROhEAD4u8wC3VjYOxsnhj3mWeGJ6N6nF/rbrcZREFr+kiYm9I5LMrzdK9t9hBMbL2Q==
+  dependencies:
+    chardet "^2.0.0"
+    cheerio "^1.0.0-rc.12"
+    iconv-lite "^0.6.3"
+    undici "^6.21.0"
+
 optionator@^0.9.3:
   version "0.9.4"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.9.4.tgz#7ea1c1a5d91d764fb282139c88fe11e182a3a734"
@@ -2437,6 +2564,28 @@ parent-module@^1.0.0:
   integrity sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
   dependencies:
     callsites "^3.0.0"
+
+parse5-htmlparser2-tree-adapter@^7.0.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz#b5a806548ed893a43e24ccb42fbb78069311e81b"
+  integrity sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==
+  dependencies:
+    domhandler "^5.0.3"
+    parse5 "^7.0.0"
+
+parse5-parser-stream@^7.1.2:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz#d7c20eadc37968d272e2c02660fff92dd27e60e1"
+  integrity sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==
+  dependencies:
+    parse5 "^7.0.0"
+
+parse5@^7.0.0, parse5@^7.1.2:
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-7.2.1.tgz#8928f55915e6125f430cc44309765bf17556a33a"
+  integrity sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==
+  dependencies:
+    entities "^4.5.0"
 
 path-exists@^4.0.0:
   version "4.0.0"
@@ -2826,6 +2975,11 @@ safe-regex-test@^1.0.3, safe-regex-test@^1.1.0:
     call-bound "^1.0.2"
     es-errors "^1.3.0"
     is-regex "^1.2.1"
+
+"safer-buffer@>= 2.1.2 < 3.0.0":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
+  integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
 sass@^1.77.8:
   version "1.83.0"
@@ -3230,6 +3384,11 @@ undici-types@~6.20.0:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.20.0.tgz#8171bf22c1f588d1554d55bf204bc624af388433"
   integrity sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==
 
+undici@^6.19.5, undici@^6.21.0:
+  version "6.21.1"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-6.21.1.tgz#336025a14162e6837e44ad7b819b35b6c6af0e05"
+  integrity sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==
+
 uri-js@^4.2.2:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.1.tgz#9b1a52595225859e55f669d928f88c6c57f2a77e"
@@ -3246,6 +3405,18 @@ w3c-keyname@^2.2.0:
   version "2.2.8"
   resolved "https://registry.yarnpkg.com/w3c-keyname/-/w3c-keyname-2.2.8.tgz#7b17c8c6883d4e8b86ac8aba79d39e880f8869c5"
   integrity sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==
+
+whatwg-encoding@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz#d0f4ef769905d426e1688f3e34381a99b60b76e5"
+  integrity sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==
+  dependencies:
+    iconv-lite "0.6.3"
+
+whatwg-mimetype@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz#bc1bf94a985dc50388d54a9258ac405c3ca2fc0a"
+  integrity sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==
 
 which-boxed-primitive@^1.1.0, which-boxed-primitive@^1.1.1:
   version "1.1.1"


### PR DESCRIPTION
## 📌 관련 이슈

- https://github.com/Kumoh-talk/kumoh-talk-Frontend/issues/50

## ✨ PR 세부 내용

- 링크 미리보기 기능 구현
  - 링크 미리보기 요구 사항에 따른 커스텀 컴포넌트 및 기능을 구현
  - open graph의 메타 데이터 조회를 위한 `open-graph-scraper` 추가
  - 메타 데이터 추출을 위한 route 추가
  - 메타 데이터 조회 및 처리 기능 구현
  - 조회 실패 시 해당 url에 해당하는 노드 삭제 
  - 링크 미리보기 조회 시 사용될 serialized HTML 구조 추가
  - UX 향상을 위한 스켈레톤 UI 구현
- next/image hostname 이슈에 따른 remotePatterns 추가

## 📸 스크린샷
![링크 미리보기 추가 기능](https://github.com/user-attachments/assets/d1c0330e-5f37-492e-9bfa-6b236b314793)

## ✅ 리뷰 요구사항
- 사용자 제공 url에 대한 조회 실패 시 호스트 url로 조회하도록 구현했습니다. 더 나은 방안 혹은 로직 개선 대한 의견 있으시면 부탁드립니다.
- 사용자가 어떤 hostname의 url을 조회할지 알 수 없기에 protocol을 https인 경우 모두 허용했습니다. 제한할 url 들에 대한 추가적인 논의가 필요할 것 같습니다.
