### PR TITLE
에디터 이미지 copy & paste, drag & drop, 대표 이미지 기능 구현

### DIFF
--- a/src/app/components/post/Draft/DraftItem.tsx
+++ b/src/app/components/post/Draft/DraftItem.tsx
@@ -1,3 +1,5 @@
+import { usePostContent } from '@/app/lib/contexts/post/PostContentContext';
+import { toast } from 'react-toastify';
 import TrashSvg from '@/app/assets/svg/Editor/TrashSvg';
 import { MSG } from '@/app/lib/constants/post/board';
 import styles from './Draft.module.scss';
@@ -11,7 +13,14 @@ interface DraftItemProps {
 }
 
 const DraftItem = ({ boardId, updatedAt, title, loadDraft, onDelete }: DraftItemProps) => {
+  const {boardId: curBoardId} = usePostContent();
+  
   const handleDeleteClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    if(boardId === curBoardId){
+      toast.warn('현재 작성 중인 글입니다.');
+      return;
+    }
+
     e.stopPropagation();
 
     setTimeout(() => {

--- a/src/app/components/post/ImageNode/ImageComponent.module.scss
+++ b/src/app/components/post/ImageNode/ImageComponent.module.scss
@@ -22,6 +22,37 @@
     height: auto;
   }
 
+  .headImageChip {
+    position: absolute;
+    right: 1rem;
+    bottom: 1rem;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 0.25rem 0.5rem;
+    width: 4rem;
+    background-color: #fff;
+    opacity: 0.5;
+    border: 1px solid gray;
+    border-radius: 1rem;
+    white-space: normal;
+    transition: background-color 0.1s ease, color 0.1s ease;
+    cursor: pointer;
+
+    > div {
+      font-size: 13px;
+      display: flex;
+      align-items: center;
+      gap : 0.3rem;
+    }
+
+    &.active {
+      background-color: rgb(36, 36, 36);
+      color: white;
+      opacity: 0.8;
+    }
+  }
+
   .resizeTrigger {
     position: absolute;
     right: -4px;

--- a/src/app/components/post/ImageNode/ImageComponent.tsx
+++ b/src/app/components/post/ImageNode/ImageComponent.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import clsx from 'clsx';
 import { NodeViewWrapper } from '@tiptap/react';
 import { usePostContent } from '@/app/lib/contexts/post/PostContentContext';
@@ -91,6 +91,14 @@ const ImageComponent = ({
       setBoardHeadImageUrl(src);
     }
   };
+
+  useEffect(() => {
+    return () => {
+      if (boardHeadImageUrl === src) {
+        setBoardHeadImageUrl('');
+      }
+    };
+  }, [boardHeadImageUrl]);
 
   return (
     <NodeViewWrapper

--- a/src/app/components/post/ImageNode/ImageComponent.tsx
+++ b/src/app/components/post/ImageNode/ImageComponent.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import clsx from 'clsx';
 import { NodeViewWrapper } from '@tiptap/react';
+import { usePostContent } from '@/app/lib/contexts/post/PostContentContext';
 import AlignLeftSvg from '@/app/assets/svg/Editor/AlignLeftSvg';
 import AlignCenterSvg from '@/app/assets/svg/Editor/AlignCenterSvg';
 import AlignRightSvg from '@/app/assets/svg/Editor/AlignRightSvg';
@@ -16,6 +17,8 @@ const ImageComponent = ({
   const containerStyle = { width, height, margin };
 
   const [imgCaption, setImgCaption] = useState(caption);
+
+  const { boardHeadImageUrl, setBoardHeadImageUrl } = usePostContent();
 
   const AlignController = () => {
     return (
@@ -81,6 +84,14 @@ const ImageComponent = ({
     updateAttributes({ caption: newCaption });
   };
 
+  const toggleBoardHeadImageUrl = () => {
+    if (boardHeadImageUrl === src) {
+      setBoardHeadImageUrl('');
+    } else {
+      setBoardHeadImageUrl(src);
+    }
+  };
+
   return (
     <NodeViewWrapper
       className={clsx(styles.wrapper, { [styles.selected]: selected })}
@@ -93,6 +104,26 @@ const ImageComponent = ({
           <div className={styles.resizeTrigger} onMouseDown={resizeHandler}>
             <div className={styles.resizeHandle} />
           </div>
+          {selected && (
+            <div
+              className={clsx(styles.headImageChip, {
+                [styles.active]: boardHeadImageUrl === src,
+              })}
+              onClick={toggleBoardHeadImageUrl}
+            >
+              {boardHeadImageUrl === src ? (
+                <div>
+                  <span>✔</span>
+                  <span>대표</span>
+                </div>
+              ) : (
+                <div>
+                  <span>○</span>
+                  <span>대표</span>
+                </div>
+              )}
+            </div>
+          )}
         </div>
 
         {(imgCaption || selected) && (

--- a/src/app/components/post/ImageNode/ImageComponent.tsx
+++ b/src/app/components/post/ImageNode/ImageComponent.tsx
@@ -84,20 +84,20 @@ const ImageComponent = ({
     updateAttributes({ caption: newCaption });
   };
 
-  const toggleBoardHeadImageUrl = () => {
+  const toggleBoardHeadImage = () => {
     if (boardHeadImageUrl === src) {
+      updateAttributes({ isBoardHeadImage: false });
       setBoardHeadImageUrl('');
     } else {
+      updateAttributes({ isBoardHeadImage: true });
       setBoardHeadImageUrl(src);
     }
   };
 
   useEffect(() => {
-    return () => {
-      if (boardHeadImageUrl === src) {
-        setBoardHeadImageUrl('');
-      }
-    };
+    if (boardHeadImageUrl !== src) {
+      updateAttributes({ isBoardHeadImage: false });
+    }
   }, [boardHeadImageUrl]);
 
   return (
@@ -117,7 +117,7 @@ const ImageComponent = ({
               className={clsx(styles.headImageChip, {
                 [styles.active]: boardHeadImageUrl === src,
               })}
-              onClick={toggleBoardHeadImageUrl}
+              onClick={toggleBoardHeadImage}
             >
               {boardHeadImageUrl === src ? (
                 <div>

--- a/src/app/components/post/ImageNode/ImageNode.tsx
+++ b/src/app/components/post/ImageNode/ImageNode.tsx
@@ -50,11 +50,21 @@ const CustomImage = Image.extend({
             const file = imageItem.getAsFile();
             if (!file) return false;
 
+            const mimeType = file.type;
+            const ext = mimeType.split('/')[1] || 'png';
+            let fileName = '';
+
+            if (file.name && file.name.trim() !== '') {
+              fileName = file.name;
+            } else {
+              fileName === `image-${Date.now()}.${ext}`;
+            }
+
             const reader = new FileReader();
             reader.onload = (e) => {
               const result = e.target?.result;
               if (typeof result === 'string') {
-                this.editor.commands.setImage({ src: result });
+                this.editor.commands.setImage({ src: result, title: fileName });
               } else {
                 console.error('Unexpected result type:', result);
               }

--- a/src/app/components/post/ImageNode/ImageNode.tsx
+++ b/src/app/components/post/ImageNode/ImageNode.tsx
@@ -65,9 +65,38 @@ const CustomImage = Image.extend({
           },
         },
       }),
+      new Plugin({
+        key: new PluginKey('dropImage'),
+        props: {
+          handleDrop: (view, event, slice) => {
+            const dataTransfer = event.dataTransfer;
+            if (!dataTransfer) return false;
+
+            const files = dataTransfer.files;
+            if (!files || files.length === 0) return false;
+
+            const imageFile = Array.from(files).find(
+              (file) => file.type.indexOf('image') === 0
+            );
+            if (!imageFile) return false;
+
+            const reader = new FileReader();
+            reader.onload = (e) => {
+              const result = e.target?.result;
+              if (typeof result === 'string') {
+                this.editor.commands.setImage({ src: result });
+              } else {
+                console.error('Unexpected result type:', result);
+              }
+            };
+            reader.readAsDataURL(imageFile);
+
+            return true;
+          },
+        },
+      }),
     ];
   },
-
   parseHTML() {
     return [
       {

--- a/src/app/components/post/ImageNode/ImageNode.tsx
+++ b/src/app/components/post/ImageNode/ImageNode.tsx
@@ -29,6 +29,7 @@ const CustomImage = Image.extend({
       height: { default: 'auto' },
       margin: { default: '0 auto' },
       caption: { default: '' },
+      isBoardHeadImage: { default: false },
     };
   },
 
@@ -107,6 +108,7 @@ const CustomImage = Image.extend({
       }),
     ];
   },
+
   parseHTML() {
     return [
       {
@@ -125,6 +127,7 @@ const CustomImage = Image.extend({
             height: container?.style.height || 'auto',
             margin: container?.style.margin || '0 auto',
             caption: caption?.textContent || '',
+            isBoardHeadImage : img?.getAttribute('data-is-head-image') || false
           };
         },
       },
@@ -132,7 +135,7 @@ const CustomImage = Image.extend({
   },
 
   renderHTML({ node }) {
-    const { src, alt, title, width, height, margin, caption } = node.attrs;
+    const { src, alt, title, width, height, margin, caption, isBoardHeadImage } = node.attrs;
 
     return [
       'div',
@@ -157,6 +160,7 @@ const CustomImage = Image.extend({
               src,
               alt,
               title,
+              'data-is-head-image' : isBoardHeadImage
             },
           ],
         ],

--- a/src/app/lib/apis/post/saveFiles.ts
+++ b/src/app/lib/apis/post/saveFiles.ts
@@ -76,7 +76,6 @@ const submitImageUrls = async (boardId: number, presignedUrls: string[]) => {
 };
 
 const saveImages = async (editor: Editor, boardId: number) => {
-  const serializedHTML = editor.getHTML();
   const customImageNodes = findImageNodes(editor);
   const files = extractFilesFromImageNodes(customImageNodes);
 
@@ -85,6 +84,13 @@ const saveImages = async (editor: Editor, boardId: number) => {
   await uploadImages(files, presignedUrls);
   await submitImageUrls(boardId, presignedUrls);
 
+  return { customImageNodes, presignedUrls };
+};
+
+const getReplacedContents = async (editor: Editor, boardId: number) => {
+  const serializedHTML = editor.getHTML();
+  const { customImageNodes, presignedUrls } = await saveImages(editor, boardId);
+
   const replacedHTML = replaceUrls(
     serializedHTML,
     customImageNodes,
@@ -92,7 +98,7 @@ const saveImages = async (editor: Editor, boardId: number) => {
   );
 
   return replacedHTML;
-};
+}
 
 const getAttachPresignedURL = async (boardId: number, attachNodes: Array<any>) => {
   const presignedUrls: string[] = [];
@@ -173,4 +179,4 @@ const saveAttaches = async (editor: Editor, boardId: number) => {
   return replacedHTML;
 };
 
-export { saveImages, saveAttaches };
+export { saveImages, saveAttaches, getReplacedContents };

--- a/src/app/lib/hooks/post/useAutoSave.ts
+++ b/src/app/lib/hooks/post/useAutoSave.ts
@@ -4,14 +4,14 @@ import { useCurrentEditor } from '@tiptap/react';
 import { usePostContent } from '@/app/lib/contexts/post/PostContentContext';
 import { createDraft, editDraft } from '@/app/lib/apis/post/saveDraft';
 import { useInitBoardId } from '@/app/lib/hooks/post/useInitBoardId';
-import { includesCustomNode } from '@/app/lib/utils/post/editorFileUtils';
-import { saveImages, saveAttaches, getReplacedContents } from '@/app/lib/apis/post/saveFiles';
+import { includesCustomNode, findBoardHeadImageUrl } from '@/app/lib/utils/post/editorFileUtils';
+import { saveAttaches, getReplacedContents } from '@/app/lib/apis/post/saveFiles';
 import { getHHmmssFormat } from '@/app/lib/utils/post/dateFormatter';
 import { AUTO_SAVE_DELAY } from '@/app/lib/constants/post/board';
 
 const useAutoSave = () => {
-  const { boardId, setBoardId, title, tagList, boardHeadImageUrl, boardType } =
-    usePostContent();
+  const { boardId, setBoardId, title, tagList, boardHeadImageUrl, setBoardHeadImageUrl, boardType } 
+    = usePostContent();
   const { editor } = useCurrentEditor();
   const { initBoardId } = useInitBoardId();
   const contents = editor?.getHTML() || '<p></p>';
@@ -39,10 +39,13 @@ const useAutoSave = () => {
     const attachNode = includesCustomNode(editor, 'ATTACH');
 
     let replacedContents = editor.getHTML();
+    let boardHeadImage = '';
 
     if (boardId) {
       if (imageNode) {
         replacedContents = await getReplacedContents(editor, boardId);
+        boardHeadImage = findBoardHeadImageUrl(replacedContents) ?? '';
+        setBoardHeadImageUrl(boardHeadImage);
         editor.commands.setContent(replacedContents);
       }
 
@@ -56,7 +59,7 @@ const useAutoSave = () => {
         title,
         contents: replacedContents,
         categoryName: tagList,
-        boardHeadImageUrl,
+        boardHeadImageUrl: boardHeadImage,
       });
 
       setLastSavedAt(getHHmmssFormat(new Date()));
@@ -73,6 +76,8 @@ const useAutoSave = () => {
 
       if (imageNode) {
         replacedContents = await getReplacedContents(editor, newBoardId);
+        boardHeadImage = findBoardHeadImageUrl(replacedContents) ?? '';
+        setBoardHeadImageUrl(boardHeadImage);
         editor.commands.setContent(replacedContents);
       }
 
@@ -86,7 +91,7 @@ const useAutoSave = () => {
         title,
         contents: replacedContents,
         categoryName: tagList,
-        boardHeadImageUrl,
+        boardHeadImageUrl: boardHeadImage,
       });
 
       setLastSavedAt(getHHmmssFormat(new Date()));

--- a/src/app/lib/hooks/post/useAutoSave.ts
+++ b/src/app/lib/hooks/post/useAutoSave.ts
@@ -5,7 +5,7 @@ import { usePostContent } from '@/app/lib/contexts/post/PostContentContext';
 import { createDraft, editDraft } from '@/app/lib/apis/post/saveDraft';
 import { useInitBoardId } from '@/app/lib/hooks/post/useInitBoardId';
 import { includesCustomNode } from '@/app/lib/utils/post/editorFileUtils';
-import { saveImages, saveAttaches } from '@/app/lib/apis/post/saveFiles';
+import { saveImages, saveAttaches, getReplacedContents } from '@/app/lib/apis/post/saveFiles';
 import { getHHmmssFormat } from '@/app/lib/utils/post/dateFormatter';
 import { AUTO_SAVE_DELAY } from '@/app/lib/constants/post/board';
 
@@ -42,7 +42,7 @@ const useAutoSave = () => {
 
     if (boardId) {
       if (imageNode) {
-        replacedContents = await saveImages(editor, boardId);
+        replacedContents = await getReplacedContents(editor, boardId);
         editor.commands.setContent(replacedContents);
       }
 
@@ -72,7 +72,7 @@ const useAutoSave = () => {
       setBoardId(newBoardId);
 
       if (imageNode) {
-        replacedContents = await saveImages(editor, newBoardId);
+        replacedContents = await getReplacedContents(editor, newBoardId);
         editor.commands.setContent(replacedContents);
       }
 

--- a/src/app/lib/hooks/post/useDrafts.ts
+++ b/src/app/lib/hooks/post/useDrafts.ts
@@ -16,7 +16,7 @@ export const useDrafts = (close: () => void) => {
     setBoardId(boardId);
     setTitle(title);
     setTagList(categoryNames);
-    setBoardHeadImageUrl(boardHeadImageUrl);
+    setBoardHeadImageUrl(boardHeadImageUrl?.split('?')[0] || '');
     editor.commands.setContent(contents);
   };
 

--- a/src/app/lib/hooks/post/useSaveDraft.ts
+++ b/src/app/lib/hooks/post/useSaveDraft.ts
@@ -3,11 +3,11 @@ import { useCurrentEditor } from '@tiptap/react';
 import { usePostContent } from '@/app/lib/contexts/post/PostContentContext';
 import { createDraft, editDraft } from '@/app/lib/apis/post/saveDraft';
 import { useInitBoardId } from '@/app/lib/hooks/post/useInitBoardId';
-import { includesCustomNode } from '@/app/lib/utils/post/editorFileUtils';
-import { saveImages, saveAttaches, getReplacedContents } from '@/app/lib/apis/post/saveFiles';
+import { includesCustomNode, findBoardHeadImageUrl } from '@/app/lib/utils/post/editorFileUtils';
+import { saveAttaches, getReplacedContents } from '@/app/lib/apis/post/saveFiles';
 
 export const useSaveDraft = (close: () => void) => {
-  const { boardId, setBoardId, title, tagList, boardHeadImageUrl, boardType } =
+  const { boardId, setBoardId, title, tagList, setBoardHeadImageUrl, boardType } =
     usePostContent();
   const { editor } = useCurrentEditor();
   const { initBoardId } = useInitBoardId();
@@ -31,10 +31,13 @@ export const useSaveDraft = (close: () => void) => {
     const attachNode = includesCustomNode(editor, 'ATTACH');
 
     let contents = editor.getHTML();
+    let boardHeadImageUrl = '';
 
     if (boardId) {
       if (imageNode) {
         contents = await getReplacedContents(editor, boardId);
+        boardHeadImageUrl = findBoardHeadImageUrl(contents) ?? '';
+        setBoardHeadImageUrl(boardHeadImageUrl);
         editor.commands.setContent(contents);
       }
 
@@ -69,6 +72,8 @@ export const useSaveDraft = (close: () => void) => {
 
       if (imageNode) {
         contents = await getReplacedContents(editor, newBoardId);
+        boardHeadImageUrl = findBoardHeadImageUrl(contents) ?? '';
+        setBoardHeadImageUrl(boardHeadImageUrl);
         editor.commands.setContent(contents);
       }
 

--- a/src/app/lib/hooks/post/useSaveDraft.ts
+++ b/src/app/lib/hooks/post/useSaveDraft.ts
@@ -4,7 +4,7 @@ import { usePostContent } from '@/app/lib/contexts/post/PostContentContext';
 import { createDraft, editDraft } from '@/app/lib/apis/post/saveDraft';
 import { useInitBoardId } from '@/app/lib/hooks/post/useInitBoardId';
 import { includesCustomNode } from '@/app/lib/utils/post/editorFileUtils';
-import { saveImages, saveAttaches } from '@/app/lib/apis/post/saveFiles';
+import { saveImages, saveAttaches, getReplacedContents } from '@/app/lib/apis/post/saveFiles';
 
 export const useSaveDraft = (close: () => void) => {
   const { boardId, setBoardId, title, tagList, boardHeadImageUrl, boardType } =
@@ -34,7 +34,7 @@ export const useSaveDraft = (close: () => void) => {
 
     if (boardId) {
       if (imageNode) {
-        contents = await saveImages(editor, boardId);
+        contents = await getReplacedContents(editor, boardId);
         editor.commands.setContent(contents);
       }
 
@@ -68,7 +68,7 @@ export const useSaveDraft = (close: () => void) => {
       setBoardId(newBoardId);
 
       if (imageNode) {
-        contents = await saveImages(editor, newBoardId);
+        contents = await getReplacedContents(editor, newBoardId);
         editor.commands.setContent(contents);
       }
 

--- a/src/app/lib/utils/post/editorFileUtils.ts
+++ b/src/app/lib/utils/post/editorFileUtils.ts
@@ -45,6 +45,14 @@ const findAttachNodes = (editor: Editor) => {
   return attachNodes;
 };
 
+const findBoardHeadImageUrl = (contents : string) => {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(contents, 'text/html');
+  const headImage = doc.querySelector('img.editorImage[data-is-head-image="true"]');
+
+  return headImage ? headImage.getAttribute('src') : null;
+}
+
 const convertBase64ToFile = (base64: string, fileName: string): File => {
   const [header, data] = base64.split(',');
   const mimeMatch = header.match(/:(.*?);/);
@@ -132,6 +140,7 @@ export {
   includesCustomNode,
   findImageNodes,
   findAttachNodes,
+  findBoardHeadImageUrl,
   extractFilesFromImageNodes,
   extractFilesFromAttachNodes,
   replaceUrls,


### PR DESCRIPTION
## 📌 관련 이슈

- https://github.com/Kumoh-talk/kumoh-talk-Frontend/issues/50

## ✨ PR 세부 내용

### FEATURE

#### 1️⃣ 이미지 유틸리티 기능 구현
> 이미지 copy & paste plugin 추가 및 기능 구현
> 이미지 drag & drop plugin 추가 및 기능 구현

#### 2️⃣ 대표 이미지 기능 구현
> 대표 이미지 토글 버튼 UI 및 대표 이미지 토글 기능 구현

### **FIXED**
- 현재 작성 중인 글은 삭제할 수 없도록 수정

## 📸 기능 설명 & 스크린샷
### **이미지 copy & paste, drag & drop**
![이미지 copy paste - drag drop 구현](https://github.com/user-attachments/assets/50279386-5465-4530-b15e-b4d328b6c269)

<br/>

이제 에디터에 이미지를 copy & paste, drag & drop이 가능합니다 : )

### **대표 이미지 기능**
![image](https://github.com/user-attachments/assets/8787bbb0-7233-4e86-ba30-52c5707e8c18)
![image](https://github.com/user-attachments/assets/e832cd5d-44ed-47e6-9f04-f0297c93fb19)

<br/>
대표 이미지를 설정하고 싶으면 이미지를 선택한 뒤 '대표' 버튼을 클릭해주세요. 

검은색 바탕에 '✔ 대표'인 경우 대표 이미지로 선택된 것 입니다. 

대표 이미지를 해제하고 싶으면 '대표' 버튼을 클릭해주세요. 

만약 다른 이미지를 대표 이미지로 설정한 경우 기존 대표 이미지는 해제됩니다.


## ✅ 리뷰 요구사항
- 대표 이미지 설정 뒤 게시글 생성 / 수정 / 자동 생성 / 자동 수정 케이스에 대해 테스트를 해봤지만 예외 상황이 있을 수 있어 추가적인 QA가 필요합니다. 이슈가 생기면 바로 말씀해주세요!