### PR TITLE
메인 홈 공지사항 레이아웃 및 게시글 조회 시 개행 문제 수정

### DIFF
--- a/src/app/assets/svg/BoardViewSvg.tsx
+++ b/src/app/assets/svg/BoardViewSvg.tsx
@@ -1,0 +1,22 @@
+export default function BoardViewSvg({
+  className = '',
+}: {
+  className?: string;
+}) {
+  return (
+    <svg
+      xmlns='http://www.w3.org/2000/svg'
+      width='24'
+      height='24'
+      viewBox='0 0 24 24'
+      fill='none'
+      className={className}
+    >
+      <path
+        d='M12 5C6.55576 5 3.53109 9.23425 2.45554 11.1164C2.23488 11.5025 2.12456 11.6956 2.1367 11.9836C2.14885 12.2716 2.27857 12.4598 2.53799 12.8362C3.8182 14.6935 7.29389 19 12 19C16.7061 19 20.1818 14.6935 21.462 12.8362C21.7214 12.4598 21.8511 12.2716 21.8633 11.9836C21.8754 11.6956 21.7651 11.5025 21.5445 11.1164C20.4689 9.23425 17.4442 5 12 5Z'
+        stroke='currentColor'
+      />
+      <circle cx='12' cy='12' r='3' stroke='currentColor' />
+    </svg>
+  );
+}

--- a/src/app/components/front/noticeList/noticeItem.module.scss
+++ b/src/app/components/front/noticeList/noticeItem.module.scss
@@ -10,15 +10,16 @@
   }
 
   .titleWrapper {
-    display: inline;
+    display: flex;
     flex: 1;
     width: 0;
+
     .title {
       @include title2Emphasized(black-85);
       overflow: hidden;
       white-space: nowrap;
       text-overflow: ellipsis;
-      word-break: break-all;
+      flex: 1;
     }
 
     .new {

--- a/src/app/components/front/seminarList/SeminarItem.tsx
+++ b/src/app/components/front/seminarList/SeminarItem.tsx
@@ -1,4 +1,4 @@
-import SeminarCommentSvg from '@/app/assets/svg/SeminarCommentSvg';
+import BoardViewSvg from '@/app/assets/svg/BoardViewSvg';
 import styles from './seminarItem.module.scss';
 import Link from 'next/link';
 
@@ -24,7 +24,7 @@ export default function SeminarItem(props: BoardItemProps) {
             <img
               className={styles.thumbnail}
               src={props.headImageUrl}
-              alt="썸네일"
+              alt='썸네일'
             />
           )}
         </div>
@@ -33,7 +33,7 @@ export default function SeminarItem(props: BoardItemProps) {
           <span className={styles.title}>{props.title}</span>
           <span className={styles.sub}>
             <span className={styles.author}>{props.userName}</span>
-            <SeminarCommentSvg />
+            <BoardViewSvg />
             <span>{props.view}</span>
           </span>
         </div>

--- a/src/app/components/front/seminarList/seminarItem.module.scss
+++ b/src/app/components/front/seminarList/seminarItem.module.scss
@@ -55,9 +55,12 @@
       text-overflow: ellipsis;
       word-break: break-all;
       display: inline-flex;
+      align-items: center;
 
       svg {
-        margin: 0 0.5rem;
+        width : 18px;
+        height : 18px;
+        margin: 0 0.3rem;
       }
     }
   }

--- a/src/app/components/front/seminarList/seminarList.module.scss
+++ b/src/app/components/front/seminarList/seminarList.module.scss
@@ -6,8 +6,8 @@
   filter: drop-shadow(0rem 0rem 2px rgba(0, 0, 0, 0.55))
     drop-shadow(0rem 33.5px 83.75px rgba(0, 0, 0, 0.1));
   display: grid;
-  grid-template-columns: repeat(4, 188px);
-  grid-template-rows: repeat(3, 188px);
+  grid-template-columns: repeat(4, 168px);
+  grid-template-rows: repeat(3, 168px);
   gap: 1.125rem;
   padding: 1.125rem;
 

--- a/src/app/components/notice/Board.module.scss
+++ b/src/app/components/notice/Board.module.scss
@@ -113,6 +113,12 @@
   .contents {
     @include editorContent;
 
+    p:empty::after {
+      content: '';
+      display: block;
+      height: 1rem;
+    }
+
     // CustomImageNode
     :global(.editorCustomImage) {
       height: fit-content;


### PR DESCRIPTION
## 📌 관련 이슈

- https://github.com/Kumoh-talk/kumoh-talk-Frontend/issues/139

## ✨ PR 세부 내용

- 메인 홈에서 댓글 이미지가 아닌, 조회수 이미지로 변경
- 게시글 조회 시 개행이 적용되도록 수정
- 공지사항 레이아웃 수정 및 말줄임 처리

## 📸 스크린샷

**레이아웃 수정 및 말줄임 처리**
![image](https://github.com/user-attachments/assets/7691c968-e768-474f-8c16-25aafc3c479e)

<br/>

**게시글 조회 시 개행 적용**
![image](https://github.com/user-attachments/assets/bee6a717-09ef-4f01-972e-85f79c997a75)
