### PR TITLE
공지사항 / 세미나 목록 페이지 구현

### DIFF
--- a/src/app/components/front/noticeList/NoticeList.tsx
+++ b/src/app/components/front/noticeList/NoticeList.tsx
@@ -27,7 +27,7 @@ export default async function NoticeList() {
     <section className={styles.container}>
       <header>
         <span>공지사항</span>
-        <Link href="/recruitment-boards?category=mentor">
+        <Link href="/notice">
           더 보기
           <PageMoreSvg />
         </Link>

--- a/src/app/components/front/noticeList/noticeList.module.scss
+++ b/src/app/components/front/noticeList/noticeList.module.scss
@@ -17,7 +17,6 @@
       @include title3Emphasized();
       color: var(--color-gray-900);
       display: flex;
-      display: none;
       flex-direction: row;
       align-items: center;
       gap: 0.5rem;

--- a/src/app/components/front/seminarList/SeminarItem.tsx
+++ b/src/app/components/front/seminarList/SeminarItem.tsx
@@ -18,7 +18,7 @@ export interface BoardItemProps {
 export default function SeminarItem(props: BoardItemProps) {
   return (
     <li className={styles.container}>
-      <Link href={`/notice/${props.boardId}`}>
+      <Link href={`/seminar/${props.boardId}`}>
         <div className={styles.thumbWrapper}>
           {props.headImageUrl && (
             <img

--- a/src/app/components/notice/NoticeItem/NoticeItem.module.scss
+++ b/src/app/components/notice/NoticeItem/NoticeItem.module.scss
@@ -1,0 +1,47 @@
+@import 'mixin';
+
+.item {
+  @include title3(black-85);
+
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: 3.375rem;
+  border-top: 1px solid var(--color-gray-600);
+
+  .title {
+    flex: 3;
+    padding-left: 0.5rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
+    a:hover {
+      text-decoration: underline;
+    }
+  }
+
+  .author,
+  .datetime,
+  .view,
+  .like {
+    text-align: center;
+    min-width: fit-content;
+  }
+
+  .author {
+    flex: 1;
+  }
+
+  .datetime {
+    flex: 1;
+  }
+
+  .view {
+    flex: 0.8;
+  }
+
+  .like {
+    flex: 0.8;
+  }
+}

--- a/src/app/components/notice/NoticeItem/NoticeItem.module.scss
+++ b/src/app/components/notice/NoticeItem/NoticeItem.module.scss
@@ -1,8 +1,6 @@
 @import 'mixin';
 
 .item {
-  @include title3(black-85);
-
   display: flex;
   align-items: center;
   width: 100%;
@@ -10,6 +8,8 @@
   border-top: 1px solid var(--color-gray-600);
 
   .title {
+    @include title3(black-85);
+
     flex: 3;
     padding-left: 0.5rem;
     overflow: hidden;
@@ -25,6 +25,8 @@
   .datetime,
   .view,
   .like {
+    @include title3(black-50);
+
     text-align: center;
     min-width: fit-content;
   }

--- a/src/app/components/notice/NoticeItem/NoticeItem.tsx
+++ b/src/app/components/notice/NoticeItem/NoticeItem.tsx
@@ -1,0 +1,21 @@
+import Link from 'next/link';
+import type { BoardArticle } from '@/app/lib/types/board/board';
+import styles from './NoticeItem.module.scss';
+
+const NoticeItem = ({ notice }: { notice: BoardArticle }) => {
+  const { boardId, title, userName, view, like, createdAt } = notice;
+
+  return (
+    <li className={styles.item}>
+      <span className={styles.title}>
+        <Link href={`notice/${boardId}`}>{title}</Link>
+      </span>
+      <span className={styles.author}>{userName}</span>
+      <span className={styles.datetime}>{createdAt.slice(0, 10)}</span>
+      <span className={styles.view}>{view}</span>
+      <span className={styles.like}>{like}</span>
+    </li>
+  );
+};
+
+export default NoticeItem;

--- a/src/app/components/notice/NoticeList/NoticeList.module.scss
+++ b/src/app/components/notice/NoticeList/NoticeList.module.scss
@@ -1,0 +1,38 @@
+@import 'mixin';
+
+.list {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  min-height: 23.625rem;
+
+  & > li:last-child {
+    border-bottom: 1px solid var(--color-gray-600);
+  }
+
+  .empty {
+    @include title3(black-85);
+
+    align-self: center;
+    padding: 3rem 0;
+  }
+
+  .dummy {
+    width: 100%;
+    height: 1.875rem;
+    background: var(--color-gray-500);
+    border-radius: 0.5rem;
+    user-select: none;
+  }
+
+  .line {
+    background: var(--color-gray-600);
+    height: 1px;
+    margin: 0.75rem 0;
+    user-select: none;
+
+    &:first-child {
+      margin-top: 0;
+    }
+  }
+}

--- a/src/app/components/notice/NoticeList/NoticeList.tsx
+++ b/src/app/components/notice/NoticeList/NoticeList.tsx
@@ -1,0 +1,30 @@
+import { getBoards } from '@/app/lib/apis/notice/notice';
+import NoticeItem from '@/app/components/notice/NoticeItem/NoticeItem';
+import type { BoardSearchParams } from '@/app/lib/types/notice/board';
+import type { BoardArticle } from '@/app/lib/types/board/board';
+import styles from './NoticeList.module.scss';
+
+export default async function NoticeList({ searchParams }: BoardSearchParams) {
+  const page = searchParams.page ?? '1';
+  const sort = searchParams.sort ?? 'DESC';
+
+  const noticeList: BoardArticle[] = [];
+
+  try {
+    noticeList.push(...(await getBoards('NOTICE', page, '15', sort)));
+  } catch (error) {
+    console.error(error);
+  }
+
+  return (
+    <ul className={styles.list}>
+      {noticeList.length > 0 ? (
+        noticeList.map((notice) => (
+          <NoticeItem key={notice.boardId} notice={notice} />
+        ))
+      ) : (
+        <div className={styles.empty}>공지사항이 없습니다.</div>
+      )}
+    </ul>
+  );
+}

--- a/src/app/components/notice/NoticeList/NoticeListSuspense.tsx
+++ b/src/app/components/notice/NoticeList/NoticeListSuspense.tsx
@@ -1,0 +1,17 @@
+import { Fragment } from 'react';
+import styles from './NoticeList.module.scss';
+
+const NoticeListSuspense = () => {
+  return (
+    <ul className={styles.list}>
+      {Array.from({ length: 7 }, (_, idx) => (
+        <Fragment key={idx}>
+          <div className={styles.line}></div>
+          <li className={styles.dummy}></li>
+        </Fragment>
+      ))}
+    </ul>
+  );
+};
+
+export default NoticeListSuspense;

--- a/src/app/components/notice/NoticeSort/NoticeSort.module.scss
+++ b/src/app/components/notice/NoticeSort/NoticeSort.module.scss
@@ -1,0 +1,13 @@
+@import 'mixin';
+
+.sort {
+  @include body(secondary);
+
+  display: flex;
+  flex-direction: row;
+  gap: 1rem;
+
+  .selected {
+    @include bodyEmphasized(black-85);
+  }
+}

--- a/src/app/components/notice/NoticeSort/NoticeSort.tsx
+++ b/src/app/components/notice/NoticeSort/NoticeSort.tsx
@@ -1,0 +1,36 @@
+import Link from 'next/link';
+import clsx from 'clsx';
+import type { BoardSearchParams } from '@/app/lib/types/notice/board';
+import styles from './NoticeSort.module.scss';
+
+const SORT_OPTIONS = [
+  { value: 'DESC', label: '최신순' },
+  { value: 'ASC', label: '오래된 순' },
+] as const;
+
+const NoticeSort = ({ searchParams }: BoardSearchParams) => {
+  const currentSort = searchParams?.sort ?? 'DESC';
+
+  return (
+    <div className={styles.sort}>
+      {SORT_OPTIONS.map(({ value, label }) => {
+        const newSearchParams = new URLSearchParams(searchParams);
+        newSearchParams.set('sort', value);
+
+        return (
+          <Link
+            className={clsx(styles.link, {
+              [styles.selected]: currentSort === value,
+            })}
+            key={value}
+            href={`?${newSearchParams.toString()}`}
+          >
+            {label}
+          </Link>
+        );
+      })}
+    </div>
+  );
+};
+
+export default NoticeSort;

--- a/src/app/components/seminar/SeminarItem/SeminarItem.module.scss
+++ b/src/app/components/seminar/SeminarItem/SeminarItem.module.scss
@@ -1,0 +1,65 @@
+@import 'mixin';
+
+.item {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: 5.375rem;
+  border-top: 1px solid var(--color-gray-600);
+
+  .imageContainer {
+    flex-shrink: 0;
+    width: 4.5rem;
+    height: 4.5rem;
+    margin-left: 0.5rem;
+    border : 1px solid var(--color-gray-600);
+    border-radius: 8px;
+  }
+
+  .image {
+    width : 100%;
+    height : 100%;
+    object-fit: cover;
+    border-radius: 8px;
+  }
+
+  .title {
+    @include title3(black-85);
+
+    flex: 3;
+    padding-left: 1.5rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
+    a:hover {
+      text-decoration: underline;
+    }
+  }
+
+  .author,
+  .datetime,
+  .view,
+  .like {
+    @include title3(black-50);
+
+    text-align: center;
+    min-width: fit-content;
+  }
+
+  .author {
+    flex: 1;
+  }
+
+  .datetime {
+    flex: 1;
+  }
+
+  .view {
+    flex: 0.8;
+  }
+
+  .like {
+    flex: 0.8;
+  }
+}

--- a/src/app/components/seminar/SeminarItem/SeminarItem.tsx
+++ b/src/app/components/seminar/SeminarItem/SeminarItem.tsx
@@ -1,0 +1,24 @@
+import Link from 'next/link';
+import type { BoardArticle } from '@/app/lib/types/board/board';
+import styles from './SeminarItem.module.scss';
+
+const SeminarItem = ({ seminar }: { seminar: BoardArticle }) => {
+  const { boardId, title, userName, view, like, headImageUrl, createdAt } = seminar;
+
+  return (
+    <li className={styles.item}>
+      <div className={styles.imageContainer}>
+        <img className={styles.image} src={headImageUrl} alt={`${title}_image`}/>
+      </div>
+      <span className={styles.title} role='link'>
+        <Link href={`seminar/${boardId}`}>{title}</Link>
+      </span>
+      <span className={styles.author}>{userName}</span>
+      <span className={styles.datetime}>{createdAt.slice(0, 10)}</span>
+      <span className={styles.view}>{view}</span>
+      <span className={styles.like}>{like}</span>
+    </li>
+  );
+};
+
+export default SeminarItem;

--- a/src/app/components/seminar/SeminarList/SeminarList.module.scss
+++ b/src/app/components/seminar/SeminarList/SeminarList.module.scss
@@ -1,0 +1,19 @@
+@import 'mixin';
+
+.list {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  min-height: 37.625rem;
+
+  & > li:last-child {
+    border-bottom: 1px solid var(--color-gray-600);
+  }
+
+  .empty {
+    @include title3(black-85);
+
+    align-self: center;
+    padding: 3rem 0;
+  }
+}

--- a/src/app/components/seminar/SeminarList/SeminarList.tsx
+++ b/src/app/components/seminar/SeminarList/SeminarList.tsx
@@ -1,0 +1,30 @@
+import { getBoards } from '@/app/lib/apis/notice/notice';
+import SeminarItem from '@/app/components/seminar/SeminarItem/SeminarItem';
+import type { BoardSearchParams } from '@/app/lib/types/notice/board';
+import type { BoardArticle } from '@/app/lib/types/board/board';
+import styles from './SeminarList.module.scss';
+
+export default async function SeminarList({ searchParams }: BoardSearchParams) {
+  const page = searchParams.page ?? '1';
+  const sort = searchParams.sort ?? 'DESC';
+
+  const seminarList: BoardArticle[] = [];
+
+  try {
+    seminarList.push(...(await getBoards('SEMINAR', page, '15', sort)));
+  } catch (error) {
+    console.error(error);
+  }
+
+  return (
+    <ul className={styles.list}>
+      {seminarList.length > 0 ? (
+        seminarList.map((seminar) => (
+          <SeminarItem key={seminar.boardId} seminar={seminar} />
+        ))
+      ) : (
+        <div className={styles.empty}>세미나 글이 없습니다.</div>
+      )}
+    </ul>
+  );
+}

--- a/src/app/components/seminar/SeminarList/SeminarListSuspense.tsx
+++ b/src/app/components/seminar/SeminarList/SeminarListSuspense.tsx
@@ -1,0 +1,20 @@
+import { Fragment } from 'react';
+import styles from './SeminarList.module.scss';
+
+const SeminarListSuspense = () => {
+  return (
+    <ul className={styles.list}>
+      {Array.from({ length: 7 }, (_, idx) => (
+        <Fragment key={idx}>
+          <div className={styles.line}/>
+          <div className={styles.dummy}>
+            <div className={styles.image}/>
+            <li className={styles.info}/>
+          </div>
+        </Fragment>
+      ))}
+    </ul>
+  );
+};
+
+export default SeminarListSuspense;

--- a/src/app/components/seminar/SeminarSort/SeminarSort.module.scss
+++ b/src/app/components/seminar/SeminarSort/SeminarSort.module.scss
@@ -1,0 +1,13 @@
+@import 'mixin';
+
+.sort {
+  @include body(secondary);
+
+  display: flex;
+  flex-direction: row;
+  gap: 1rem;
+
+  .selected {
+    @include bodyEmphasized(black-85);
+  }
+}

--- a/src/app/components/seminar/SeminarSort/SeminarSort.tsx
+++ b/src/app/components/seminar/SeminarSort/SeminarSort.tsx
@@ -1,0 +1,36 @@
+import Link from 'next/link';
+import clsx from 'clsx';
+import type { BoardSearchParams } from '@/app/lib/types/notice/board';
+import styles from './SeminarSort.module.scss';
+
+const SORT_OPTIONS = [
+  { value: 'DESC', label: '최신순' },
+  { value: 'ASC', label: '오래된 순' },
+] as const;
+
+const SeminarSort = ({ searchParams }: BoardSearchParams) => {
+  const currentSort = searchParams?.sort ?? 'DESC';
+
+  return (
+    <div className={styles.sort}>
+      {SORT_OPTIONS.map(({ value, label }) => {
+        const newSearchParams = new URLSearchParams(searchParams);
+        newSearchParams.set('sort', value);
+
+        return (
+          <Link
+            className={clsx(styles.link, {
+              [styles.selected]: currentSort === value,
+            })}
+            key={value}
+            href={`?${newSearchParams.toString()}`}
+          >
+            {label}
+          </Link>
+        );
+      })}
+    </div>
+  );
+};
+
+export default SeminarSort;

--- a/src/app/lib/apis/notice/notice.ts
+++ b/src/app/lib/apis/notice/notice.ts
@@ -1,3 +1,5 @@
+import type { BoardType, BoardSort } from "@/app/lib/types/notice/board";
+
 const baseUrl = `${process.env.NEXT_PUBLIC_BASE_URL}/api`;
 
 const _fetch = async (
@@ -24,6 +26,42 @@ export const getBoard = (boardId: number) => {
   });
 };
 
+export const getBoards = async (
+  boardType: BoardType,
+  page: string = '1',
+  size: string = '15',
+  sort: BoardSort
+) => {
+  const query = new URLSearchParams({
+    boardType,
+    size,
+    page,
+    sort: `createdAt,${sort}`,
+  });
+
+  try {
+    const response = await _fetch(`${baseUrl}/boards/?${query.toString()}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      credentials: 'include',
+    });
+
+    if (response.success === 'true') {
+      console.log(response.data.pageContents);
+
+      return response.data.pageContents;
+    } else {
+      console.error('Failed to fetch data:', response);
+      return [];
+    }
+  } catch (error) {
+    console.error('Error fetching data:', error);
+    return [];
+  }
+};
+
 export const getMyInformation = () => {
   return _fetch(`${baseUrl}/users/me`, {
     method: 'GET',
@@ -33,7 +71,6 @@ export const getMyInformation = () => {
     credentials: 'include',
   });
 };
-
 
 export const deleteBoard = (boardId: number) => {
   return _fetch(`${baseUrl}/boards/${boardId}`, {

--- a/src/app/lib/types/notice/board.ts
+++ b/src/app/lib/types/notice/board.ts
@@ -1,0 +1,10 @@
+export type BoardType = 'SEMINAR' | 'NOTICE';
+
+export type BoardSort = 'DESC' | 'ASC';
+
+export interface BoardSearchParams {
+  searchParams: {
+    page?: string;
+    sort?: BoardSort;
+  };
+}

--- a/src/app/notice/[id]/page.tsx
+++ b/src/app/notice/[id]/page.tsx
@@ -1,6 +1,5 @@
 import Header from '@/app/components/common/header/Header';
 import ApplyBanner from '@/app/components/front/applyBanner/ApplyBanner';
-import Footer from '@/app/components/common/footer/Footer';
 import Board from '@/app/components/notice/Board';
 import styles from './page.module.scss';
 
@@ -25,7 +24,6 @@ export default function Notice({ params }: NoticePageProps) {
         </header>
         <Board boardId ={Number(id)}/>
       </main>
-      <Footer />
     </>
   );
 }

--- a/src/app/notice/layout.tsx
+++ b/src/app/notice/layout.tsx
@@ -1,0 +1,10 @@
+import Footer from '@/app/components/common/footer/Footer';
+
+export default function NoticeLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      {children}
+      <Footer />
+    </>
+  );
+}

--- a/src/app/notice/page.module.scss
+++ b/src/app/notice/page.module.scss
@@ -1,0 +1,85 @@
+@import 'mixin';
+
+html:has(.main) {
+  font-size: 100%;
+}
+
+.main {
+  display: flex;
+  flex-direction: column;
+  max-width: 70rem;
+  margin: 10.5rem auto 8.25rem;
+  width: 90%;
+
+  header {
+    @include largeTitleEmphasized(black-85);
+    margin-bottom: 1.5rem;
+  }
+
+  @include mobile-header {
+    margin: 5.875rem 1rem 3rem;
+    padding-top: 0.5rem;
+
+    header {
+      display: none;
+    }
+  }
+
+  .container {
+    display: flex;
+    flex-direction: column;
+
+    .aside {
+      display: flex;
+      justify-content: flex-end;
+    }
+
+    .header {
+      @include headline(black-50);
+
+      display: flex;
+      align-items: center;
+      height: 2.5rem;
+      margin-top: 1.125rem;
+      border-top: 1px solid var(--color-gray-600);
+
+      .title {
+        flex: 3;
+        padding-left: 0.5rem;
+        text-align: center;
+      }
+
+      .author,
+      .datetime,
+      .view,
+      .like {
+        text-align: center;
+        min-width: fit-content;
+      }
+
+      .author {
+        flex: 1;
+      }
+
+      .datetime {
+        flex: 1;
+      }
+
+      .view {
+        flex: 0.8;
+      }
+
+      .like {
+        flex: 0.8;
+      }
+    }
+  }
+
+  .bottom {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding-top: 1rem;
+    margin-top: 1.125rem;
+  }
+}

--- a/src/app/notice/page.tsx
+++ b/src/app/notice/page.tsx
@@ -1,0 +1,37 @@
+import { Suspense } from 'react';
+import Header from '@/app/components/common/header/Header';
+import NoticeListSuspense from '@/app/components/notice/NoticeList/NoticeListSuspense';
+import NoticeList from '@/app/components/notice/NoticeList/NoticeList';
+import NoticeSort from '@/app/components/notice/NoticeSort/NoticeSort';
+import Pagination from '@/app/components/articles/Pagination';
+import type { BoardSearchParams } from '@/app/lib/types/notice/board';
+import styles from './page.module.scss';
+
+export default function Notice({ searchParams }: BoardSearchParams) {
+  return (
+    <>
+      <Header title='공지사항' />
+      <main className={styles.main}>
+        <header>공지사항</header>
+        <div className={styles.container}>
+          <div className={styles.aside}>
+            <NoticeSort searchParams={searchParams} />
+          </div>
+          <div className={styles.header}>
+            <span className={styles.title}>제목</span>
+            <span className={styles.author}>작성자</span>
+            <span className={styles.datetime}>작성일</span>
+            <span className={styles.view}>조회</span>
+            <span className={styles.like}>좋아요</span>
+          </div>
+          <Suspense fallback={<NoticeListSuspense />}>
+            <NoticeList searchParams={searchParams} />
+          </Suspense>
+          <div className={styles.bottom}>
+            <Pagination searchParams={searchParams} />
+          </div>
+        </div>
+      </main>
+    </>
+  );
+}

--- a/src/app/seminar/[id]/page.module.scss
+++ b/src/app/seminar/[id]/page.module.scss
@@ -1,0 +1,41 @@
+@import 'mixin';
+
+html:has(.main) {
+  font-size: 100%;
+}
+
+.main {
+  display: flex;
+  flex-direction: column;
+  gap: 5rem;
+  max-width: 79.5rem;
+  margin: 0 auto;
+  padding: 2.5rem 1rem 1.5rem;
+
+  & > header {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    gap: 2.5rem;
+
+    .logo {
+      align-self: center;
+      height: 3rem;
+    }
+
+    .bannerWrapper {
+      display: flex;
+      flex-direction: column;
+      gap: 1.25rem;
+      align-items: center;
+    }
+  }
+
+  @include mobile-header {
+    padding-top: 3.875rem;
+
+    & > header .logo {
+      display: none;
+    }
+  }
+}

--- a/src/app/seminar/[id]/page.tsx
+++ b/src/app/seminar/[id]/page.tsx
@@ -1,0 +1,29 @@
+import Header from '@/app/components/common/header/Header';
+import ApplyBanner from '@/app/components/front/applyBanner/ApplyBanner';
+import Board from '@/app/components/notice/Board';
+import styles from './page.module.scss';
+
+interface SeminarPageProps {
+  params: {
+    id: string;
+  };
+}
+
+export default function Seminar({ params }: SeminarPageProps) {
+  const { id } = params;
+
+  return (
+    <>
+      <Header title='세미나' alwaysVisible={false} />
+      <main className={styles.main}>
+        <header>
+          <div className={styles.logo}></div>
+          <div className={styles.bannerWrapper}>
+            <ApplyBanner />
+          </div>
+        </header>
+        <Board boardId ={Number(id)}/>
+      </main>
+    </>
+  );
+}

--- a/src/app/seminar/layout.tsx
+++ b/src/app/seminar/layout.tsx
@@ -1,0 +1,10 @@
+import Footer from '@/app/components/common/footer/Footer';
+
+export default function SeminarLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      {children}
+      <Footer />
+    </>
+  );
+}

--- a/src/app/seminar/page.module.scss
+++ b/src/app/seminar/page.module.scss
@@ -43,21 +43,15 @@ html:has(.main) {
       margin-top: 1.125rem;
       border-top: 1px solid var(--color-gray-600);
 
-      .thumbnail {
-        flex: 0.8;
-        text-align: center;
-    
-        img {
-          width: 100%;
-          height: auto;
-          max-width: 50px;
-          object-fit: cover;
-        }
+      .image {
+        flex-shrink: 0;
+        width: 4.5rem;
+        margin-left: 0.5rem;
       }
 
       .title {
         flex: 3;
-        padding-left: 0.5rem;
+        padding-left: 1.5rem;
         text-align: center;
       }
 

--- a/src/app/seminar/page.tsx
+++ b/src/app/seminar/page.tsx
@@ -1,0 +1,38 @@
+import { Suspense } from 'react';
+import Header from '@/app/components/common/header/Header';
+import SeminarListSuspense from '@/app/components/seminar/SeminarList/SeminarListSuspense';
+import SeminarList from '@/app/components/seminar/SeminarList/SeminarList';
+import SeminarSort from '@/app/components/seminar/SeminarSort/SeminarSort';
+import Pagination from '@/app/components/articles/Pagination';
+import type { BoardSearchParams } from '@/app/lib/types/notice/board';
+import styles from './page.module.scss';
+
+export default function Seminar({ searchParams }: BoardSearchParams) {
+  return (
+    <>
+      <Header title='세미나' />
+      <main className={styles.main}>
+        <header>세미나</header>
+        <div className={styles.container}>
+          <div className={styles.aside}>
+            <SeminarSort searchParams={searchParams} />
+          </div>
+          <div className={styles.header}>
+            <span className={styles.image} />
+            <span className={styles.title}>제목</span>
+            <span className={styles.author}>작성자</span>
+            <span className={styles.datetime}>작성일</span>
+            <span className={styles.view}>조회</span>
+            <span className={styles.like}>좋아요</span>
+          </div>
+          <Suspense fallback={<SeminarListSuspense />}>
+            <SeminarList searchParams={searchParams} />
+          </Suspense>
+          <div className={styles.bottom}>
+            <Pagination searchParams={searchParams} />
+          </div>
+        </div>
+      </main>
+    </>
+  );
+}


### PR DESCRIPTION
## 📌 관련 이슈

- https://github.com/Kumoh-talk/kumoh-talk-Frontend/issues/139

## ✨ PR 세부 내용

- 공지사항 / 세미나 라우팅 분리 ( https://kumoh-talk.com/notice , https://kumoh-talk.com/seminar )
- 공지사항 / 세미나 목록 조회 페이지 구현

## 📸 스크린샷

**공지사항 목록 조회 페이지**
![image](https://github.com/user-attachments/assets/acf2e0ba-acc5-48d4-a677-daaa4538a3b4)

**세미나 목록 조회 페이지**
![image](https://github.com/user-attachments/assets/55959590-974f-4ce8-a94a-3210955132ec)


